### PR TITLE
(feat) Add a model at runtime, and have a link to best run

### DIFF
--- a/dss/src/api.py
+++ b/dss/src/api.py
@@ -32,11 +32,18 @@ async def status(req, resp, * , exec_id):
 
 @api.route("/best_run/{exec_id}")
 async def run_zip(req, resp, *, exec_id):
-    status = processing.get_status(exec_id)
-    if status != "COMPLETED":
-        raise KeyError
+    try:
+        status = processing.get_status(exec_id)
+        if status != "COMPLETED":
+            raise KeyError
+        
+        resp.content = processing.get_best_run(exec_id)
+        resp.mimetype = "application/zip"  
+    except KeyError:
+        resp.status_code = 400
+        resp.media = {'exec_id': exec_id}        
     
-    resp.content = processing.get_best_run(exec_id)    
+  
 
 
 @api.route("/dss")

--- a/dss/src/api.py
+++ b/dss/src/api.py
@@ -30,6 +30,15 @@ async def status(req, resp, * , exec_id):
         resp.media["result"] = result
         logging.info(result)
 
+@api.route("/best_run/{exec_id}")
+async def run_zip(req, resp, *, exec_id):
+    status = processing.get_status(exec_id)
+    if status != "COMPLETED":
+        raise KeyError
+    
+    resp.content = processing.get_best_run(exec_id)    
+
+
 @api.route("/dss")
 async def exec_dss(req, resp):
     """

--- a/dss/src/processing.py
+++ b/dss/src/processing.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 import tempfile
 import uuid
-from zipfile import ZipFile
+import zipfile
 
 EXECUTIONS = {}
 MODELS = {}
@@ -88,7 +88,7 @@ class Execution:
 
         # create a zip file with all of the relevant run files (inputs and outputs used for analysis)
         best_run_out_dir = os.path.join(BEST_RUNS_DIR, self.exec_id)
-        os.mkdir(best_run_out_dir)
+        os.makedirs(best_run_out_dir, exist_ok=True)
         best_run_zip_path = os.path.join(best_run_out_dir, 'best_run.zip')
         create_run_zip(best_run[0], params, best_run_zip_path)
         
@@ -147,7 +147,7 @@ def create_run_zip(run_dir, params, run_zip_name):
     input_files = params['model_run']['input_files']    
     out_file = params['model_analysis']['output_file']    
 
-    with ZipFile(run_zip_name, 'w') as run_zip:
+    with zipfile.ZipFile(run_zip_name, 'w') as run_zip:
         for in_file in input_files:
             run_zip.write(os.path.join(run_dir, in_file['name']), in_file['name'])
         
@@ -258,7 +258,7 @@ def add_model(model_name, model_contents):
     if model_name in MODELS:
         raise Exception(f"model {model_name} already exists in DB")
     model_dir = os.path.join(f"/models/{model_name}")
-    model_zip = ZipFile(BytesIO(model_contents))    
+    model_zip = zipfile.ZipFile(BytesIO(model_contents))    
     model_zip.extractall(model_dir)
     MODELS[model_name] = model_dir
 

--- a/dss/src/processing.py
+++ b/dss/src/processing.py
@@ -16,6 +16,7 @@ MODELS = {}
 
 MODEL_EXE = os.environ.get("WQDSS_MODEL_EXE", "/dss-bin/w2_exe_linux_par")
 BASE_MODEL_DIR = os.environ.get("WQDSS_BASE_MODEL_DIR", "/models")
+BEST_RUNS_DIR = os.environ.get("WQDSS_BASE_MODEL_DIR", "/best_runs")
 DEFAULT_MODEL = "default"
 
 logger = logging.getLogger()
@@ -84,6 +85,13 @@ class Execution:
         
         run_scores = [(run_dir, p, get_run_score(run_dir, params)) for (run_dir, p) in self.runs]        
         best_run = max(run_scores, key= lambda x: x[2])
+
+        # create a zip file with all of the relevant run files (inputs and outputs used for analysis)
+        best_run_out_dir = os.path.join(BEST_RUNS_DIR, self.exec_id)
+        os.mkdir(best_run_out_dir)
+        best_run_zip_path = os.path.join(best_run_out_dir, 'best_run.zip')
+        create_run_zip(best_run[0], params, best_run_zip_path)
+        
         return {'best_run': best_run[0], 'params': best_run[1], 'score': best_run[2]}
 
 async def execute_run_async(execution, params, run_permutation):
@@ -135,6 +143,15 @@ def update_inputs_for_run(run_dir, params, input_values):
                 row[out_param] = input_values[i['name']]
                 writer.writerow(row)
 
+def create_run_zip(run_dir, params, run_zip_name):
+    input_files = params['model_run']['input_files']    
+    out_file = params['model_analysis']['output_file']    
+
+    with ZipFile(run_zip_name, 'w') as run_zip:
+        for in_file in input_files:
+            run_zip.write(os.path.join(run_dir, in_file['name']), in_file['name'])
+        
+        run_zip.write(os.path.join(run_dir, out_file), out_file)    
 
 def prepare_run_dir(exec_id, params, param_values):
     '''
@@ -220,6 +237,11 @@ def get_status(exec_id):
 
 def get_result(exec_id):
     return EXECUTIONS[exec_id].result
+
+def get_best_run(exec_id):
+    """ Returns a zip file containing the outputs of the best run for the execution. """
+    best_run_out_dir = os.path.join(BEST_RUNS_DIR, exec_id, 'best_run.zip')
+    return open(best_run_out_dir, 'rb').read()
 
 
 async def execute_dss(exec_id, params):

--- a/dss/src/static/index.html
+++ b/dss/src/static/index.html
@@ -4,21 +4,26 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>WQ2 Decision Support System</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- 
-        <link rel="stylesheet" type="text/css" media="screen" href="main.css">
-    -->
+    <meta name="viewport" content="width=device-width, initial-scale=1">    
+    <link rel="stylesheet" type="text/css" media="screen" href="main.css">
     <script src="static/main.js"></script>
     <script lang="javascript"> 
         document.addEventListener('DOMContentLoaded', function () {
+            const modelFormElement = document.getElementById("form-model-upload")
             const selectElement = document.getElementById("select-model-list")
             const formElement = document.getElementById("form-dss")
             const resultElement = document.getElementById("div-results")
-            setup(selectElement, formElement, resultElement)
+            setup(modelFormElement, selectElement, formElement, resultElement)
         })
     </script>
 </head>
-<body>    
+<body>            
+    <div id="div-model-submit">
+        <form id="form-model-upload">            
+            <p><label for="input-model-file">Model zip File:</label><input id="input-model-file" name="model" type="file"></input></p>
+            <p><button type="submit" id="button-submit-dss">Upload Model</button></p>
+        </form>
+    </div>
     <div id="div-dss-submit">
         <form id="form-dss">
             <p><label for="select-model-list">Model:</label><select id="select-model-list" name="model_name"></select></p>

--- a/dss/src/static/main.js
+++ b/dss/src/static/main.js
@@ -1,22 +1,37 @@
-function setup(selectElement, formElement, resultElement) {
-    populateModelsInselect(selectElement)
+function setup(modelFormElement, selectElement, formElement, resultElement) {
+    
     formElement.addEventListener("submit", function (event) {
-        event.preventDefault();
-        executeDss(formElement);
-    });
+        event.preventDefault()
+        executeDss(formElement)
+    })
 
-    // create a closure to wrap updates
+    modelFormElement.addEventListener("submit", function(event) {
+        event.preventDefault()
+        uploadModel(modelFormElement)
+    })
+
+    // create closures to wrap updates
     function updateResults(e) {
         dssUpdate(resultElement, e)
     }
+    
+    function updateModelList(e) {
+        populateModelsInselect(selectElement)
+    }
+
     formElement.addEventListener('dssUpdate', updateResults)
+    modelFormElement.addEventListener('modelUpdate', updateModelList)
+    updateModelList()
+
 }
 
 function populateModelsInselect(selectElement) {    
     fetch('models')
         .then(response => response.json())
         .then((data) => {
-            console.log(data)            
+            console.log(data)
+            selectElement.options.length = 0; // clear any previous options
+
             data["models"].forEach((element, key) => {
                 selectElement[key] = new Option(element, element)
             });
@@ -60,5 +75,16 @@ function monitorExecution(executionId, form) {
 
 function dssUpdate(resultElement, e) {
     resultElement.innerHTML += `<pre>${JSON.stringify(e.detail)}</pre>`
+}
 
+function uploadModel(modelFormElement) {
+    var formData = new FormData(modelFormElement)    
+    fetch('add-model', {
+            method: 'POST',
+            body: formData})
+        .then(response => response.json())
+        .then((data) => {
+            console.log(data)
+            modelFormElement.dispatchEvent(new CustomEvent("modelUpdate", { detail: data }))
+        })
 }

--- a/dss/src/static/main.js
+++ b/dss/src/static/main.js
@@ -64,6 +64,7 @@ function monitorExecution(executionId, form) {
                 console.log(data)                
                 if (data['status'] === 'COMPLETED') {
                     console.log("Processing is complete")
+                    data['link'] = `best_run/${executionId}`
                 } else {                    
                     setTimeout(monitorThis, 5000)
                 }
@@ -75,6 +76,9 @@ function monitorExecution(executionId, form) {
 
 function dssUpdate(resultElement, e) {
     resultElement.innerHTML += `<pre>${JSON.stringify(e.detail)}</pre>`
+    if (e.detail.link !== undefined) {
+        resultElement.innerHTML += `<a href=${e.detail.link}>best run</a>`
+    }
 }
 
 function uploadModel(modelFormElement) {

--- a/dss/test/processing_test.py
+++ b/dss/test/processing_test.py
@@ -2,7 +2,7 @@ import itertools
 import os
 import shutil
 
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock, Mock
 import pytest
 from pytest import approx
 from asynctest import CoroutineMock
@@ -57,12 +57,14 @@ async def test_execute_dss():
         return run_dir
 
     with patch('processing.exec_model_async', new=CoroutineMock()) as exec_model:
-        with patch('processing.prepare_run_dir') as prepare_run_dir:            
-            prepare_run_dir.side_effect = create_out_csv
-            await processing.execute_dss(exec_id, params)            
+        with patch('processing.prepare_run_dir') as prepare_run_dir:
+            with patch('processing.create_run_zip') as create_run_zip:
+                prepare_run_dir.side_effect = create_out_csv
+                await processing.execute_dss(exec_id, params)            
         
     assert exec_model.call_count == 6 * 3  #  6 values for q_in, 3 values for hangq01
     assert prepare_run_dir.call_count == 6 * 3
+    assert create_run_zip.call_count == 1 # called once for the best run
     assert processing.get_result('foo')['score'] == approx(2.175)    
 
 
@@ -148,3 +150,20 @@ async def test_model_or_dir_dont_exist():
         await processing.execute_dss('this-will-fail', test_params)
 
     assert excinfo.value.model_dir == '/test/does-not-exist'
+
+
+def test_create_run_zip():
+
+    test_params = dict(params)
+    run_dir = '/foo/bar'
+    run_zip_name = 'myfoo.zip'
+
+    # The ZipFile object is used as a context manager, so mock the __enter__ call  
+    context_mock = Mock()
+    zipfile_obj = MagicMock(__enter__=Mock(return_value=context_mock))
+    with patch('zipfile.ZipFile', return_value=zipfile_obj) as zip_file:
+                       
+        processing.create_run_zip(run_dir, test_params, run_zip_name)
+        zip_file.assert_called_once_with(run_zip_name, 'w')
+        assert zipfile_obj is zip_file.return_value
+        assert context_mock.write.call_count == len(test_params['model_run']['input_files']) + 1  #  One additional write for output file


### PR DESCRIPTION
In order to achieve required functionality from the end-user perspective, added the missing functionality:
- Upload a model at runtime (no need to re-build docker image to use a new model)
- Get a link to the details of the best run in the DSS (includes inputs for the model, and output of the run)