### PR TITLE
Use evaluna docker user

### DIFF
--- a/dss/chart/wq2dss/values.yaml
+++ b/dss/chart/wq2dss/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: "booooh/waterqualitydss"
+  repository: "evaluna/waterqualitydss"
   pullPolicy: IfNotPresent
   tag: "1572126482"
   pullSecretsName: "regcred"

--- a/dss/scripts/build_and_push_to_docker_hub.sh
+++ b/dss/scripts/build_and_push_to_docker_hub.sh
@@ -6,7 +6,7 @@ if [ "$1" == "bump" ] ; then
         bump_type="$2"
     fi
 fi
-docker_username=${DOCKER_USERNAME:-booooh}
+docker_username=${DOCKER_USERNAME:-evaluna}
 current_commit=$(git rev-parse --short HEAD)
 image_tag=${TAG:-$current_commit}
 docker build --rm -f "Dockerfile" -t waterqualitydss:latest -t "${docker_username}/waterqualitydss:$image_tag" .

--- a/dss/scripts/build_and_push_to_docker_hub.sh
+++ b/dss/scripts/build_and_push_to_docker_hub.sh
@@ -6,7 +6,7 @@ if [ "$1" == "bump" ] ; then
         bump_type="$2"
     fi
 fi
-docker_username=${DOCKER_USERNAME:-evaluna}
+docker_username=${DOCKER_USERNAME_FOR_REPO:-evaluna}
 current_commit=$(git rev-parse --short HEAD)
 image_tag=${TAG:-$current_commit}
 docker build --rm -f "Dockerfile" -t waterqualitydss:latest -t "${docker_username}/waterqualitydss:$image_tag" .


### PR DESCRIPTION
I created the evaluna dockerhub organization (https://hub.docker.com/orgs/evaluna/repositories), and changed the default location of pushing docker images to that organization.

This way, should anyone else take ownership, they won't be pushing images to my user dockerhub user.